### PR TITLE
Update npm scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.history

--- a/src/package.json
+++ b/src/package.json
@@ -2,8 +2,10 @@
   "name": "emuxo-css",
   "version": "1.0.0",
   "scripts": {
-    "browser-sync": "browser-sync start --server ../docs --files ../docs/emuxo.css ../docs/index.html",
-    "stylus": "stylus -w emuxo.styl -o ../docs/emuxo.css"
+    "start": "npm run serve:css && npm run serve:docs",
+    "serve:docs": "browser-sync start --server ../docs --files ../docs/emuxo.css ../docs/index.html",
+    "serve:css": "stylus -w emuxo.styl -o ../docs/emuxo.css &",
+    "build": "stylus emuxo.styl -o ../docs/emuxo.css"
   },
   "devDependencies": {
     "browser-sync": "^2.26.7",


### PR DESCRIPTION
Closes https://github.com/NimJay/emuxo-css/issues/4

To address this comment: "I am also wondering if, instead of npm script start, we should use npm start.", adding the start script makes npm start automatically work. 
